### PR TITLE
Fix generateForm

### DIFF
--- a/BitcartCC.php
+++ b/BitcartCC.php
@@ -135,7 +135,7 @@ class Payment_Adapter_BitcartCC implements \Box\InjectionAwareInterface
     protected function _generateForm($invoiceID)
     {
         $htmlOutput =  '<button name = "bitcart-payment" class = "btn btn-success btn-sm" onclick = "showModal();return false;">Pay now</button>';
-        $htmlOutput .= '<script src="' . $config['admin_url'] . '/modal/bitcart.js" type="text/javascript"></script>';
+        $htmlOutput .= '<script src="' . $this->config['admin_url'] . '/modal/bitcart.js" type="text/javascript"></script>';
         $htmlOutput .= '<script type=\'text/javascript\'>';
         $htmlOutput .= 'function showModal() {';
         $htmlOutput .=     'bitcart.showInvoice(\''. $invoiceID .'\');';

--- a/BitcartCC.php
+++ b/BitcartCC.php
@@ -138,7 +138,7 @@ class Payment_Adapter_BitcartCC implements \Box\InjectionAwareInterface
         $htmlOutput .= '<script src="' . $config['admin_url'] . '/modal/bitcart.js" type="text/javascript"></script>';
         $htmlOutput .= '<script type=\'text/javascript\'>';
         $htmlOutput .= 'function showModal() {';
-        $htmlOutput .=     'bitcart.showInvoice('. $invoiceID .');';
+        $htmlOutput .=     'bitcart.showInvoice(\''. $invoiceID .'\');';
         $htmlOutput .= '}
                         </script>
                         </form>';

--- a/BitcartCC.php
+++ b/BitcartCC.php
@@ -132,24 +132,17 @@ class Payment_Adapter_BitcartCC implements \Box\InjectionAwareInterface
         $this->di['db']->store($tx);
     }
 
-    /**
-     * @param string $url
-     */
     protected function _generateForm($invoiceID)
     {
-        $htmlOutput .= '<button name = "bitcart-payment" class = "btn btn-success btn-sm" onclick = "showModal();return false;">Pay now</button>';
-
-        ?>
-<script src="<?php echo $this->config['admin_url']; ?>/modal/bitcart.js" type="text/javascript"></script>
-<script type='text/javascript'>
-function showModal() {
-    bitcart.showInvoice('<?php echo $invoiceID; ?>');
-}
-</script>
-<?php
-$htmlOutput .= '</form>';
+        $htmlOutput =  '<button name = "bitcart-payment" class = "btn btn-success btn-sm" onclick = "showModal();return false;">Pay now</button>';
+        $htmlOutput .= '<script src="' . $config['admin_url'] . '/modal/bitcart.js" type="text/javascript"></script>';
+        $htmlOutput .= '<script type=\'text/javascript\'>';
+        $htmlOutput .= 'function showModal() {';
+        $htmlOutput .=     'bitcart.showInvoice('. $invoiceID .');';
+        $htmlOutput .= '}
+                        </script>
+                        </form>';
         return $htmlOutput;
-
     }
 
     public function isIpnDuplicate($txID, $txAmount)


### PR DESCRIPTION
Caught while assisting a FOSSBilling user.
Note: this doesn't completely fix their issue.

I think your team has forgotten to include the `/modal/bitcart.js` file in the repo, thus leaving the integration not completely functional