### PR TITLE
Update for FOSSBilling version 0.5.0

### DIFF
--- a/BitcartCC/BitcartCC.php
+++ b/BitcartCC/BitcartCC.php
@@ -5,12 +5,12 @@ class Payment_Adapter_BitcartCC implements \FOSSBilling\InjectionAwareInterface
 
     protected $di;
 
-    public function setDi($di)
+    public function setDi(\Pimple\Container|null $di): void
     {
         $this->di = $di;
     }
 
-    public function getDi()
+    public function getDi(): ?\Pimple\Container
     {
         return $this->di;
     }

--- a/BitcartCC/BitcartCC.php
+++ b/BitcartCC/BitcartCC.php
@@ -1,5 +1,5 @@
 <?php
-class Payment_Adapter_BitcartCC implements \Box\InjectionAwareInterface
+class Payment_Adapter_BitcartCC implements \FOSSBilling\InjectionAwareInterface
 {
     private $config = array();
 
@@ -21,7 +21,7 @@ class Payment_Adapter_BitcartCC implements \Box\InjectionAwareInterface
 
         foreach (['api_endpoint', 'admin_url', 'store_id'] as $key) {
             if (!isset($this->config[$key])) {
-                throw new \Box_Exception('Payment gateway BitcartCC is not configured. Please set ' . key);
+                throw new \Payment_Exception('The ":pay_gateway" payment gateway is not fully configured. Please configure the :missing', [':pay_gateway' => 'BitcartCC', ':missing' => $key]);
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-# BitcartCC plugin for BoxBilling/FOSSBilling
+# BitcartCC plugin for FOSSBilling
+For BoxBilling or FOSSBilling versions less than 0.5.0, you will need to use an [older version](https://github.com/bitcart/bitcart-boxbilling/tree/9aeb99cd3a59545113c2f5416d7ed63f00b149eb) of this payment gateway.
+Please keep in mind BoxBilling is unmaintained and both BoxBilling and outdated version FOSSBilling may suffer from security vulnerabilities. Additionally, no support will be provided for either.
 
 ## Integration Requirements
 
 This version requires the following:
 
-* BoxBilling/FOSSBilling instance
+* A working and up-to-date FOSSBilling instance
 * Running BitcartCC instance: [deployment guide](https://docs.bitcartcc.com/deployment)
 
 ## Installing the Plugin
 
-1. From your BoxBilling/FOSSBilling panel, go to configuration > payment gateways -> New payment gateway
+1. From your FOSSBilling panel, go to configuration > payment gateways -> New payment gateway
 
 2. Upload BitcartCC directory to the directory suggested by your deployment. [Download it](https://github.com/bitcartcc/bitcart-boxbilling/releases/latest/download/BitcartCC.zip) from this repository
 


### PR DESCRIPTION
This pull request updates the payment gateway to account for a change in the upcoming release of FOSSBilling version 0.5.0.
Without updating for this, the payment gateway will be entirely unusable. Likewise, this now means that going forward this version of the payment gateway will be completely incompatible with both older versions of FOSSBilling and **all** versions of BoxBilling.

You could maintain two separate versions of the payment gateway if you want to keep support for BoxBilling, however I would strongly recommend you just let it die and remove all official support for it. BoxBilling is not being maintained and it is unlikely it will be maintained anytime soon. I can also tell you that it is very insecure software.

I've updated the readme to reflect the change in supported software with this PR. Feel free to make any changes as you see fit